### PR TITLE
Fix database path

### DIFF
--- a/app/mineral_repository.py
+++ b/app/mineral_repository.py
@@ -13,7 +13,7 @@ class MineralRepository:
 
     def read_data_source(self):
         realpath = os.path.dirname(os.path.realpath(__file__))
-        filelocation = realpath + '\database.csv'
+        filelocation = os.path.join(realpath, 'database.csv')
         with open(filelocation) as f:
             reader = csv.reader(f)
             for row in reader:


### PR DESCRIPTION
Previously failing on Linux because of the Windows path separator "\":

Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "app/main.py", line 14, in <module>
    mineral_repo = MineralRepository()
  File "app/mineral_repository.py", line 11, in __init__
    self.read_data_source()
  File "app/mineral_repository.py", line 17, in read_data_source
    with open(filelocation) as f:
IOError: [Errno 2] No such file or directory: 'Mineral-Flowchart/app\\database.csv'
